### PR TITLE
general improvements

### DIFF
--- a/pyrcon/__init__.py
+++ b/pyrcon/__init__.py
@@ -1,2 +1,3 @@
+from .rcon import RconError
 from .rcon import RConnection
-from .q2rcon import q2RConnection
+from .q2rcon import Q2RConnection

--- a/pyrcon/q2rcon.py
+++ b/pyrcon/q2rcon.py
@@ -4,9 +4,10 @@
 
 from pyrcon import RConnection
 
+
 class Player(object):
-    def __init__(self, num, score, ping, name, lastmsg, ip_address, rate_pps,
-            ver):
+
+    def __init__(self, num, score, ping, name, lastmsg, ip_address, rate_pps, ver):
         self.num = num
         self.score = score
         self.ping = ping
@@ -19,74 +20,67 @@ class Player(object):
     def __repr__(self):
         return str(self.num)+" "+self.name
 
-class q2RConnection(RConnection):
+
+class Q2RConnection(RConnection):
 
     def __init__(self, host=None, port=27910, password=None):
-        RConnection.__init__(self, host, port, password)
+        super(Q2RConnection, self).__init__(host, port, password)
         self._maplist = self.maplist()
 
     def status(self):
-        q2map = ""
+        q2map = ''
         status = False
         playerinfo = False
-        output = self.send("status")
-        Players=[]
+        output = self.send('status')
+        players = []
         
-        lines =  output.splitlines()
+        lines = output.splitlines()
         for line in lines:
-            if playerinfo and line[0:3].strip(" ")<>"":
-                Players.append(Player(
-                        num=line[0:3],
-                        score=line[5:9],
-                        ping=line[10:14],
-                        name=line[15:29],
-                        lastmsg=line[31:38],
-                        ip_address=line[39:59],
-                        rate_pps=line[60:69],
-                        ver=line[70:73],
-                        ))
+            if playerinfo and line[0:3].strip(' ') != '':
+                players.append(Player(num=line[0:3], score=line[5:9], ping=line[10:14],
+                               name=line[15:29], lastmsg=line[31:38], ip_address=line[39:59],
+                               rate_pps=line[60:69], ver=line[70:73], ))
 
-            if status and q2map == "":
-                q2map = line.split(": ")[1]
+            if status and q2map == '':
+                q2map = line.split(': ')[1]
                 print q2map
 
-            if line == '''--- ----- ---- --------------- ------- --------------------- -------- ---''':
-                print "playerinfo start"
+            if line == """--- ----- ---- --------------- ------- --------------------- -------- ---""":
+                print 'playerinfo start'
                 playerinfo = True
                 print line[0:2]
 
-            print ">",line
-            if line.find("print") >= 0:
-                print "beginning of status"
+            print '>', line
+            if line.find('print') >= 0:
+                print 'beginning of status'
                 status = True
             
-        print "end of status"
-        print Players
+        print 'end of status'
+        print players
 
     def maplist(self):
-        output = self.send("dir maps/")
-
-        lines =  output.splitlines()
+        output = self.send('dir maps/')
+        lines = output.splitlines()
         maplist = []
 
         for line in lines:
             sline = line.strip()
-            if sline == "":
-                break #seems to duplicate from q2 
-            if sline <> "----" or sline <> 'Directory of ' or sline <> 'print':
-                maplist.append(line.split(".")[0])
+            if not sline:
+                break  # seems to duplicate from q2
+            if sline != '----' or sline != 'Directory of ' or sline != 'print':
+                maplist.append(line.split('.')[0])
 
         maplist.sort()
         return maplist
 
     def changemap(self, mapname):
         if mapname in self._maplist:
-            print "yes"
-            output = self.send("map "+mapname)
+            print 'yes'
+            output = self.send('map ' + mapname)
             print output
             for line in output:
-                if line.find("server map: ") >= 0:
-                    if line.split(":")[1] <> mapname:
+                if line.find('server map: ') >= 0:
+                    if line.split(':')[1] != mapname:
                         print "didn't change correctly to " + mapname
         else:
-            print "no"
+            print 'no'

--- a/pyrcon/rcon.py
+++ b/pyrcon/rcon.py
@@ -4,81 +4,107 @@ by Anthony Nguyen
 MIT Licensed, see LICENSE
 """
 
+import thread
 import socket
 import time
+
+
+class RconError(Exception):
+    """Raised whenever a RCON command cannot be evaluated"""
+    pass
+
 
 class RConnection(object):
     """
     Base class for an RCON "connection", even though RCON is technically
     connectionless (UDP) Initialization takes an address, port, and password
     """
-    _long_commands = ["map"]
+    _host = ''  # host where the server is
+    _port = 27960  # virtual port where to forward rcon commands
+    _password = ''  # rcon password of the server
+    _timeout = 0.5  # default socket timeout
+    _rconsendstring = '\xFF\xFF\xFF\xFFrcon {0} {1}'  # rcon command pattern
+    _rconreplystring = '\xFF\xFF\xFF\xFFprint\n'  # rcon response header
+    _badrcon_replies = ['Bad rconpassword.', 'Invalid password.']
+    _long_commands_timeout = {'map': 5.0, 'fdir': 5.0}  # custom timeouts
 
     def __init__(self, host, port, password):
+        """
+        :param host: The ip/domain where to send RCON commands
+        :param port: The port where to send RCON commands
+        :param password: The RCON password
+        :raise RconError: If it's not possible to setup the RCON interface
+        """
         self.host = host
-        try:
-            self.port = int(port)
-        except ValueError:
-            self.port = 27960
+        self.port = port
         self.password = password
+        self.lock = thread.allocate_lock()
+        self.socket = socket.socket(type=socket.SOCK_DGRAM)
+        self.socket.connect((self.host, self.port))
+        self.test()
 
-        self.connect()
+    def _get_host(self):
+        return self._host
+
+    def _set_host(self, value):
+        self._host = value.strip()
+
+    """:type : str"""
+    host = property(_get_host, _set_host)
+
+    def _get_password(self):
+        return self._password
+
+    def _set_password(self, value):
+        self._password = value.strip()
+
+    """:type : str"""
+    password = property(_get_password, _set_password)
+
+    def _get_port(self):
+        return self._port
+
+    def _set_port(self, value):
+        try:
+            self._port = int(value)
+        except ValueError:
+            pass
+
+    """:type : int"""
+    port = property(_get_port, _set_port)
 
     def __enter__(self):
         if self.test():
             return self
 
     def __exit__(self, type, value, traceback):
-        self.close()
-        return traceback if traceback else True
-
-    def connect(self):
-        """Connect function that sets up the socket
-        Meant for internal use"""
-        self.close()
-
-        self.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        self.socket.connect((self.host, self.port))
-
-    def close(self):
         try:
             self.socket.close()
-            return True
-        except AttributeError:
-            return False
-
-    def set_host(self, host):
-        self.host = host
-        self.connect()
-
-    def set_port(self, port):
-        try:
-            self.port = int(port)
-            self.connect()
-        except ValueError:
+        except (AttributeError, socket.error):
             pass
-
-    def set_password(self, password):
-        self.password = password
-        self.connect()
+        finally:
+            return traceback or True
 
     def test(self):
-        self.socket.settimeout(4)
-        try:
-            self.socket.send(b"test")
-            self.socket.recv(65535)
-            return True
-        except:
-            return False
+        """
+        Test the RCON connection
+        :raise RconError: When an invalid RCON password is supplied
+        """
+        response = self.send('status')
+        if response in self._badrcon_replies:
+            raise RconError('bad rcon password supplied')
 
     def recvall(self, timeout=0.5):
+        """
+        Receive the RCON command response
+        :param timeout: The timeout between consequent data receive
+        :return str: The RCON command response with header stripped out
+        """
+        response = ''
         self.socket.setblocking(False)
-        ret = ""
-        data = ""
-
         start = time.time()
         while True:
-            if ret and time.time() - start > timeout:
+            if response and time.time() - start > timeout:
                 break
             elif time.time() - start > timeout * 2:
                 break
@@ -86,22 +112,32 @@ class RConnection(object):
             try:
                 data = self.socket.recv(4096)
                 if data:
-                    ret += data[4:].decode()
+                    response += data.replace(self._rconreplystring, '')
                     start = time.time()
                 else:
                     time.sleep(0.1)
-            except:
+            except socket.error:
                 pass
 
-        return ret
+        return response.strip()
 
     def send(self, data):
-        self.socket.send(b"\xFF\xFF\xFF\xFF" + "rcon {0} {1}".format(
-            self.password, data).encode())
-
-        if data.split(" ")[0] in self._long_commands:
-            r = self.recvall(timeout=5)
+        """
+        Send a RCON command over the socket
+        :param data: The command to send
+        :raise RconError: When it's not possible to evaluate the command
+        :return str: The server response to the RCON command
+        """
+        try:
+            if not data:
+                raise RconError('no command supplied')
+            with self.lock:
+                self.socket.send(self._rconsendstring.format(self.password, data))
+        except socket.error, e:
+            raise RconError(e.message, e)
         else:
-            r = self.recvall()
-
-        return r
+            timeout = self._timeout
+            command = data.split(' ')[0]
+            if command in self._long_commands_timeout:
+                timeout = self._long_commands_timeout[command]
+            return self.recvall(timeout=timeout)


### PR DESCRIPTION
* PEP8
* removed RCON header from server response
* make use of locks in case different threads wants to send multiple RCON commands concurrently
* make use of properties instead of set/get (more pythonic)
* added `RconError` exception class: users will have to catch only this exception in their code
* make test function actually work and check for correct RCON password
* removed `connect` method and initialized UDP socket in object constructor
* let the socket close when used within a context manager
* changed `long_commands` list to `_long_commands_timeout` dict: specify different timeouts according to the command being evaluated

